### PR TITLE
Fix oclockvita for Adrenaline.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ target_link_libraries(oclockvita
   SceLibKernel_stub
   SceIofilemgr_stub
   SceDisplay_stub
-  SceLibc_stub
+  k
+  gcc
   ScePower_stub
 )
 

--- a/blit.c
+++ b/blit.c
@@ -1,9 +1,12 @@
 /*
 	PSP VSH 24bpp text bliter
 */
+#include <libk/stdarg.h>
+#include <libk/stdio.h>
+#include <libk/string.h>
+
 #include <psp2/types.h>
 #include <psp2/display.h>
-#include <psp2/kernel/clib.h>
 
 #include "blit.h"
 
@@ -146,7 +149,7 @@ int blit_string(int sx,int sy,const char *msg)
 
 int blit_string_ctr(int sy,const char *msg)
 {
-	int sx = 960/2-sceClibStrnlen(msg, 512)*(16/2);
+	int sx = (960 / 2) - (strlen(msg) * (16 / 2));
 	return blit_string(sx,sy,msg);
 }
 
@@ -156,7 +159,7 @@ int blit_stringf(int sx, int sy, const char *msg, ...)
 	char string[512];
 
 	va_start(list, msg);
-	sceClibVsnprintf(string, 512, msg, list);
+	vsnprintf(string, 512, msg, list);
 	va_end(list);
 
 	return blit_string(sx, sy, string);


### PR DESCRIPTION
This was found by @Rinnegatamante.
The advantage of this is that it allows it to work well on Adrenaline, and other homebrews. The downside is that if you have this and another plugin turned on, certain games don't work.